### PR TITLE
Fix run-tests workflow

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -69,12 +69,16 @@ jobs:
           name: coverage-${{ strategy.job-index }}
           path: .coverage
           retention-days: 2
+          include-hidden-files: true
+          if-no-files-found: error
 
   compute-coverage:
     runs-on: ubuntu-latest
     needs:
       - install_and_run_tests
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install coverage
         run: |
           python -m pip install coverage

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -2,8 +2,6 @@ name: Run tests on push
 
 on:
   push:
-    branches:
-      - Kerr_Equatorial_Eccentric
 
 jobs:
   install_and_run_tests:
@@ -16,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "ubuntu-22.04", "macos-13", "macos-14", "macos-15"] #, "windows-latest"]
-        python-version: ["3.12"] #["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         # cuda-version: ["12.4.0"]
 
     steps:
@@ -53,7 +51,7 @@ jobs:
 
       - name: Install coverage
         run: |
-          python -m pip install coverage
+          python -m pip install coverage[toml]
 
       - name: Run module tests
         run: |

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,52 +9,94 @@ jobs:
   install_and_run_tests:
     name: Install and run non-GPU tests
     runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash -el {0}
+    # defaults:
+    #   run:
+    #     shell: bash -el {0}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest", "macos-latest", "macos-13"] #, "windows-latest"]
+        os: ["ubuntu-24.04", "ubuntu-22.04", "macos-13", "macos-14", "macos-15"] #, "windows-latest"]
         python-version: ["3.12"] #["3.9", "3.10", "3.11", "3.12"]
         # cuda-version: ["12.4.0"]
+
     steps:
       - uses: actions/checkout@v4
-      
-      - name: Intel env setup
-        uses: conda-incubator/setup-miniconda@v3
-        if: ${{matrix.os != 'macos-latest'}}
+      - uses: actions/setup-python@v5
         with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-          environment-file: ./.ci-environments/environment.yml
-          activate-environment: test_install_env
-      
-      - name: ARM env setup
-        uses: conda-incubator/setup-miniconda@v3
-        if: ${{matrix.os == 'macos-latest'}}
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          mamba-version: "*"
-          channels: conda-forge
-          environment-file: ./.ci-environments/macos-arm-environment.yml
-          activate-environment: test_install_env
-        
-      - name: Install multispline (temporary)
-        run: python -m pip install git+https://github.com/cchapmanbird/multispline.git
+          python-version: '${{ matrix.python-version }}'
 
-      - name: Run Prebuild
+      - name: Install LAPACKE
+        uses: ConorMacBride/install-package@v1
+        with:
+          brew: lapack
+          apt: liblapacke-dev
+
+      - name: Export LAPACK pkgconfig path (macOS 13)
+        if: ${{ matrix.os == 'macos-13' }}
         run: |
-          python scripts/prebuild.py
+          echo "LAPACK_PKG_CONFIG_PATH=/usr/local/opt/lapack/lib/pkgconfig" >> "$GITHUB_ENV"
+
+      - name: Export LAPACK pkgconfig path (macOS 14 and 15)
+        if: ${{ matrix.os == 'macos-14' || matrix.os == 'macos-15' }}
+        run: |
+          echo "LAPACK_PKG_CONFIG_PATH=/opt/homebrew/opt/lapack/lib/pkgconfig" >> "$GITHUB_ENV"
 
       - name: Install package
         run: |
-          python -m pip install .
+          which python
+          export PKG_CONFIG_PATH=${LAPACK_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
+          python --version
+          python -m pip install '.[testing]' \
+            --config-settings=cmake.define.FEW_WITH_GPU=OFF \
+            --config-settings=cmake.define.FEW_LAPACKE_FETCH=OFF \
+            --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
+
+      - name: Install coverage
+        run: |
+          python -m pip install coverage
 
       - name: Run module tests
         run: |
-          cd tests/
-          python -m unittest discover
+          coverage run --source=few -m unittest discover
+
+      - name: Show coverage results
+        run: |
+          coverage report -m
+
+      - name: Upload coverage results as artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ strategy.job-index }}
+          path: .coverage
+          retention-days: 2
+
+  compute-coverage:
+    runs-on: ubuntu-latest
+    needs:
+      - install_and_run_tests
+    steps:
+      - name: Install coverage
+        run: |
+          python -m pip install coverage
+
+      - name: Retrieve release distributions
+        uses: actions/download-artifact@v4
+        with:
+          path: coverage_results/
+          merge-multiple: false
+
+      - name: Merge coverage files
+        run: |
+          coverage combine coverage_results/*/.coverage
+
+      - name: Export to Cobertura XML
+        run: |
+          coverage xml
+
+      - name: Summary
+        uses: irongut/CodeCoverageSummary@v1.3.0
+        with:
+          filename: coverage.xml
+          badge: true
+          output: both
+          thresholds: '40 80'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,3 +143,13 @@ FEW_WITH_GPU = "AUTO" # ON | OFF | AUTO
 # What CUDA architectures to target.
 # See https://cmake.org/cmake/help/latest/prop_tgt/CUDA_ARCHITECTURES.html
 FEW_CUDA_ARCH = "all"
+
+[tool.coverage]
+paths.source = [
+  "src/",
+  "**/site-packages/",
+]
+
+report.omit = [
+  "*/few/_version.py",
+]


### PR DESCRIPTION
The `run-tests` workflow has been updated to work with the new packaging system.

Tests are now executed on Ubuntu 22.04 and 24.04 as well as macOS 13, 14 and 15.

I spent a few hours trying to make them work on windows but I could not find a way for LAPACK to be built on that platform (CMake fails to properly identify the compilers I tried to enforce...).

I'd like one day to implement conda packaging of FEW and of its plugins, at that time we could use the conda environment to also run tests on windows, but for now I simply left that idea aside.

All tests passed successfully on my fork, and I also now measure the test coverage. Coverage is measured on each job, and results are also combined between the 5 targetted platforms to obtain a global coverage score (which is basically identical between all platforms since there are no piece of code which is OS dependent).

When the file-management utility will be implemented, I will slightly rework the test workflow so that a first job will prefetch all files, and then these will be made available to all test jobs through the cache system to speed them up.