### PR TITLE
Fix compatibility issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # Version file
 src/*/_version.py
+
+# Ignore symlink in editable mode
+src/few/CITATION.cff

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,4 +127,12 @@ unset(_FEW_WITH_GPU)
 add_subdirectory(src)
 
 # ---- Let CMake handle copying CITATION.cff into wheel ----
-install(FILES CITATION.cff DESTINATION few)
+if(SKBUILD_STATE STREQUAL "sdist" OR SKBUILD_STATE STREQUAL "wheel")
+  install(FILES CITATION.cff DESTINATION few)
+elseif(SKBUILD_STATE STREQUAL "editable")
+  install(CODE "execute_process( \
+  COMMAND ${CMAKE_COMMAND} -E create_symlink \
+  ${CMAKE_CURRENT_SOURCE_DIR}/CITATION.cff \
+  ${CMAKE_CURRENT_SOURCE_DIR}/src/few/CITATION.cff  \
+  )")
+endif()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,13 +32,14 @@ classifiers = [
 dynamic = [ "version" ]
 
 dependencies = [
-  "cffconvert",   # To read and validate CITATION.cff
+  "cffconvert",                            # To read and validate CITATION.cff
+  "exceptiongroup; python_version<'3.11'",
   "h5py",
   "multispline",
   "numba",
   "numpy",
-  "nvidia-ml-py", # To detect CUDA version if any
-  "pydantic",     # To handle citations and references with advanced dataclasses
+  "nvidia-ml-py",                          # To detect CUDA version if any
+  "pydantic",                              # To handle citations and references with advanced dataclasses
   "requests",
   "rich",
   "scipy",

--- a/src/few/cutils/fast_selector/__init__.py
+++ b/src/few/cutils/fast_selector/__init__.py
@@ -124,9 +124,14 @@ def try_import_nvidia_so_libs(libs: Sequence[tuple[str, str, str]]) -> None:
         failed_libs = [libs[idx][2] for idx in failed_idx]
         packages = " ".join([f"{lib[0]}" for lib in libs])
 
+        try:
+            from exceptiongroup import ExceptionGroup as ExceptionGroupFew
+        except (ImportError, ModuleNotFoundError):
+            ExceptionGroupFew = ExceptionGroup
+
         raise MissingDependency(f"Could not load the following NVidia libraries: {failed_libs}. "
                                 f"If you installed FEW using pip, you may install them by running "
-                                f"`pip install {packages}`. ") from ExceptionGroup("Following exceptions were raised when trying to load these libraries", exceptions)
+                                f"`pip install {packages}`. ") from ExceptionGroupFew("Following exceptions were raised when trying to load these libraries", exceptions)
 
 
 def try_preload_cuda12x_dynlibs():

--- a/src/few/utils/citations.py
+++ b/src/few/utils/citations.py
@@ -26,7 +26,7 @@ attribute.
 import abc
 import enum
 from pydantic import BaseModel
-from typing import Sequence
+from typing import Union, Optional, List
 from few.utils.exceptions import InvalidInputFile
 
 class HyphenUnderscoreAliasModel(BaseModel):
@@ -40,9 +40,9 @@ class Author(HyphenUnderscoreAliasModel):
     """Description of a reference author."""
     family_names: str
     given_names: str
-    orcid: str | None = None
-    affiliation: str | None = None
-    email: str | None = None
+    orcid: Optional[str] = None
+    affiliation: Optional[str] = None
+    email: Optional[str] = None
 
 class Publisher(HyphenUnderscoreAliasModel):
     """Description of a publisher."""
@@ -52,7 +52,7 @@ class Identifier(HyphenUnderscoreAliasModel):
     """Description of an identifier."""
     type: str
     value: str
-    description: str | None = None
+    description: Optional[str] = None
 
 class ReferenceABC(HyphenUnderscoreAliasModel, abc.ABC):
     """Abstract base class for references."""
@@ -64,27 +64,27 @@ class ReferenceABC(HyphenUnderscoreAliasModel, abc.ABC):
 class ArxivIdentifier(BaseModel):
     """Class representing an arXiv identifier"""
     reference: str
-    primary_class: str | None = None
+    primary_class: Optional[str] = None
 
 class ArticleReference(ReferenceABC):
     """Description of an article."""
 
     abbreviation: str
-    authors: list[Author]
+    authors: List[Author]
     title: str
     journal: str
     year: int
-    month: int | None = None
-    issue: int | None = None
-    publisher: Publisher | None = None
-    pages: int | None = None
-    start: int | None = None
-    issn : str | None = None
-    doi: str | None = None
-    identifiers: list[Identifier] | None = None
+    month: Optional[int] = None
+    issue: Optional[int] = None
+    publisher: Optional[Publisher] = None
+    pages: Optional[int] = None
+    start: Optional[int] = None
+    issn : Optional[str] = None
+    doi: Optional[str] = None
+    identifiers: Optional[List[Identifier]] = None
 
     @property
-    def arxiv_preprint(self) -> ArxivIdentifier | None:
+    def arxiv_preprint(self) -> Optional[ArxivIdentifier]:
         """
         Detect an arXiv identifier if any.
 
@@ -146,16 +146,16 @@ class SoftwareReference(ReferenceABC):
     authors: list[Author]
     title: str
 
-    license: str | None = None
-    url: str | None = None
-    repository: str | None = None
-    identifiers: list[Identifier] | None = None
-    year: int | None = None
-    month: int | None = None
-    version: str | None = None
+    license: Optional[str] = None
+    url: Optional[str] = None
+    repository: Optional[str] = None
+    identifiers: Optional[List[Identifier]] = None
+    year: Optional[int] = None
+    month: Optional[int] = None
+    version: Optional[str] = None
 
     @property
-    def doi(self) -> str | None:
+    def doi(self) -> Optional[str]:
         """Return the first DOI in identifiers if any"""
         for identifier in self.identifiers:
             if identifier.type == "doi":
@@ -190,7 +190,7 @@ class SoftwareReference(ReferenceABC):
         return ",\n".join(lines) + "\n}"
 
 
-type Reference = ArticleReference | SoftwareReference
+Reference = Union[ArticleReference, SoftwareReference]
 
 class REFERENCE(enum.Enum):
     FEW = "Chua:2020stf"
@@ -212,7 +212,7 @@ class CitationRegistry:
     def __init__(self, **kwargs):
         self.registry = kwargs
 
-    def get(self, key: str | REFERENCE) -> Reference:
+    def get(self, key: Union[str, REFERENCE]) -> Reference:
         """Return a Reference object from its key."""
         return self.registry[key if isinstance(key, str) else key.value]
 


### PR DESCRIPTION
Following tests by @lorenzsp and @cchapmanbird , here are some fixes:

- added a dependency on `exceptiongroup` to make use of `ExceptionGroup` in Python < 3.11
- reverted the type hints in `few/utils/citations.py` to *old* syntaxes compatible with Python 3.9
- Ensured that `CITATION.cff` is properly symlinked into `src/few` on editable installs

Please tell me if you face any other issue! Thanks for your tests