### PR TITLE
fix: stop reading CLI arguments in non-cli contexts

### DIFF
--- a/src/few/utils/config.py
+++ b/src/few/utils/config.py
@@ -462,11 +462,6 @@ class InitialConfigConsumer(ConfigConsumer):
         env_vars: Optional[Mapping[str, str]] = None,
         cli_args: Optional[Sequence[str]] = None,
     ):
-        if cli_args is None:
-            import sys
-
-            cli_args = sys.argv[1:]
-
         super().__init__(config_file=None, env_vars=env_vars, cli_args=cli_args)
 
 


### PR DESCRIPTION
I introduced an unwanted behavior in the configuration manager where `sys.argv` (CLI parameters) were parsed even when not using a FEW CLI utility.

@cchapmanbird noticed that this behavior conflicts with ipython_launcher in Jupyter notebook contexts (but overall, `few` should not be intercepting CLI parameters unless we are in a FEW CLI utility specifically...).