### PR TITLE
fix: project slug in documentation-links workflow

### DIFF
--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -11,4 +11,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "readthedocs-preview"
+          project-slug: "fastemriwaveforms"


### PR DESCRIPTION
Project slug was incorrectly set in the `documentation-links` workflow. This could be seen on #120 where the documentation link was set to https://readthedocs-preview--120.org.readthedocs.build/en/120/ instead of https://fastemriwaveforms--120.org.readthedocs.build/en/120/ .

This should be fixed after merging this PR.

<!-- readthedocs-preview readthedocs-preview start -->
----
📚 Documentation preview 📚: https://readthedocs-preview--121.org.readthedocs.build/en/121/

<!-- readthedocs-preview readthedocs-preview end -->