### PR TITLE
Improve file caching strategy to accelerate tests execution in CI

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -57,6 +57,7 @@ jobs:
           path: local_cache
           key: ${{ hashFiles('src/few/files/registry.yml') }}
       - name: List artifacts
+        if: ${{ steps.restore_cache.outputs.cache-hit == 'true' }}
         run: |
           ls -R ./local_cache
       - name: Export configuration options to force using prefetched cache of files

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,14 +52,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Restore the cache
         uses: actions/cache/restore@v4
+        id: restore_cache
         with:
           path: local_cache
           key: ${{ hashFiles('src/few/files/registry.yml') }}
-          fail-on-cache-miss: true
       - name: List artifacts
         run: |
           ls -R ./local_cache
       - name: Export configuration options to force using prefetched cache of files
+        if: ${{ steps.restore_cache.outputs.cache-hit == 'true' }}
         run: |
           echo "FEW_FILE_ALLOW_DOWNLOAD=no" >> "$GITHUB_ENV"
           echo "FEW_FILE_EXTRA_PATHS=$(pwd)/local_cache" >> "$GITHUB_ENV"

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,23 +7,33 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - name: Check if cache already exists
+        uses: actions/cache/restore@v4
+        id: file_cache
+        with:
+          path: local_cache
+          key: ${{ hashFiles('src/few/files/registry.yml') }}
+          lookup-only: true
+      - name: Install Python 3.12
+        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install bare package
+        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
         run: |
           python -m pip install . --config-settings=cmake.define.FEW_WITH_GPU=BARE
-      - name: Download files
+      - name: Download files into cache
+        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
         run: |
-          mkdir local_cache
+          mkdir -p local_cache
           few_files fetch --download-dir $(pwd)/local_cache --tag unittest
-      - name: Upload coverage results as artifacts
-        uses: actions/upload-artifact@v4
+      - name: Save the cache
+        uses: actions/cache/save@v4
+        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
         with:
-          name: prefetch_files
           path: local_cache
-          retention-days: 1
-          if-no-files-found: error
+          key: ${{ hashFiles('src/few/files/registry.yml') }}
   install_and_run_tests:
     name: Install and run non-GPU tests
     runs-on: ${{ matrix.os }}
@@ -40,11 +50,12 @@ jobs:
         # cuda-version: ["12.4.0"]
     steps:
       - uses: actions/checkout@v4
-      - name: Retrieve prefetched files
-        uses: actions/download-artifact@v4
+      - name: Restore the cache
+        uses: actions/cache/restore@v4
         with:
-          name: prefetch_files
           path: local_cache
+          key: ${{ hashFiles('src/few/files/registry.yml') }}
+          fail-on-cache-miss: true
       - name: List artifacts
         run: |
           ls -R ./local_cache


### PR DESCRIPTION
Hi,
I found that the previous caching strategy for the `run-tests` workflow became quite inefficient, especially since `ZNAmps_l10_m10_n55.h5` was added as a `unittest` file, the time spent building using the cache were about:

- ~5min downloading files
- ~5min30 uploading them as artifacts
- ~2 up to 16 min downloading artifacts depending on the runner (linux, macOS and specific version)

I now switched to using the actual cache mechanism instead of artifacts.
The workflow will first search for a cache whose key in the sha256 checksum of the `registry.yml` file, if that cache is non-existent (never built, or evicted from available caches by github due to storage restrictions), it is built. Then, when the jobs run, they restore that cache (and fail if the cache is not available). It seems that cache upload/download speed are far greater than for artifacts. In my tests, I observe:

- ~5min downloading file (only when building cache for the first time, this step is now often skipped)
- <1min to upload the cache (often skipped too)
- ~1 to 4min to download the cache on runners

I find this new approach must more efficient and reliable.
The only thing I'm worried about is the cache size which is about 9GB, whilst the total cache limit for github is 10GB, and cache is not often shared between branches (there are conditions for cache from one branch to be usable by another branch), so when developping on multiple branch, we could see cache eviction happening frequently (though even if cache needs to be rebuilt each and everytime, it's still faster that the current artifact approach).

If we have issue in the future due to cache size and this 10GB limit, we'll have to consider different approaches:

- Prefetch only certain files and let the runner download the other ones (so we'll only have a partial speed-up through caching and this will increase the load on the server hosting the files)
- See whether github will offer an increased cache size (this is planned as a pay-as-you-go service for [Q2 2025](https://github.com/github/roadmap/issues/1029#issue-2677331485) )
- Drop completely the file caching mechanism and let the files be redownloaded on each runner (in this case, it would make sense to reduce the matrix size by having one job per OS and let that job run tests for all python versions sequentially so that file)
- Use an alternative caching action for github actions with self-hosted S3 storage (probably overkill for our needs but still an option...)

For now, this PR should improve execution times for the run-tests workflow and that's all that matters ;)

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--126.org.readthedocs.build/en/126/

<!-- readthedocs-preview fastemriwaveforms end -->