### PR TITLE
fix: force CI to use multispline 0.8.2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -97,7 +97,8 @@ jobs:
           python -m pip install ".[${FEW_EXTRAS}]" \
             --config-settings=cmake.define.FEW_WITH_GPU=OFF \
             --config-settings=cmake.define.FEW_LAPACKE_FETCH=OFF \
-            --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
+            --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG \
+            -vvv --config-settings=cmake.verbose=true --config-settings=logging.level=INFO
       - name: Install coverage
         run: |
           python -m pip install coverage[toml]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,22 +15,22 @@ jobs:
           key: ${{ hashFiles('src/few/files/registry.yml') }}
           lookup-only: true
       - name: Install Python 3.12
-        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
+        if: steps.file_cache.outputs.cache-hit != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.12'
       - name: Install bare package
-        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
+        if: steps.file_cache.outputs.cache-hit != 'true'
         run: |
           python -m pip install . --config-settings=cmake.define.FEW_WITH_GPU=BARE
       - name: Download files into cache
-        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
+        if: steps.file_cache.outputs.cache-hit != 'true'
         run: |
           mkdir -p local_cache
           few_files fetch --download-dir $(pwd)/local_cache --tag unittest
       - name: Save the cache
         uses: actions/cache/save@v4
-        if: ${{ steps.file_cache.outputs.cache-hit != 'true' }}
+        if: steps.file_cache.outputs.cache-hit != 'true'
         with:
           path: local_cache
           key: ${{ hashFiles('src/few/files/registry.yml') }}
@@ -57,11 +57,11 @@ jobs:
           path: local_cache
           key: ${{ hashFiles('src/few/files/registry.yml') }}
       - name: List artifacts
-        if: ${{ steps.restore_cache.outputs.cache-hit == 'true' }}
+        if: steps.restore_cache.outputs.cache-hit == 'true'
         run: |
           ls -R ./local_cache
       - name: Export configuration options to force using prefetched cache of files
-        if: ${{ steps.restore_cache.outputs.cache-hit == 'true' }}
+        if: steps.restore_cache.outputs.cache-hit == 'true'
         run: |
           echo "FEW_FILE_ALLOW_DOWNLOAD=no" >> "$GITHUB_ENV"
           echo "FEW_FILE_EXTRA_PATHS=$(pwd)/local_cache" >> "$GITHUB_ENV"
@@ -74,19 +74,27 @@ jobs:
           brew: lapack pandoc
           apt: liblapacke-dev pandoc
       - name: Export LAPACK pkgconfig path (macOS 13)
-        if: ${{ matrix.os == 'macos-13' }}
+        if: matrix.os == 'macos-13'
         run: |
           echo "LAPACK_PKG_CONFIG_PATH=/usr/local/opt/lapack/lib/pkgconfig" >> "$GITHUB_ENV"
       - name: Export LAPACK pkgconfig path (macOS 14 and 15)
-        if: ${{ matrix.os == 'macos-14' || matrix.os == 'macos-15' }}
+        if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
         run: |
           echo "LAPACK_PKG_CONFIG_PATH=/opt/homebrew/opt/lapack/lib/pkgconfig" >> "$GITHUB_ENV"
+      - name: Enable doctest testing
+        run: |
+          echo "FEW_EXTRAS=testing,doc" >> "$GITHUB_ENV"
+      - name: Disable doctest testing
+        id: disabling_doctests
+        if: matrix.python-version != '3.9' &&  matrix.python-version != '3.12'
+        run: |
+          echo "FEW_EXTRAS=testing" >> "$GITHUB_ENV"
       - name: Install package
         run: |
           which python
           export PKG_CONFIG_PATH=${LAPACK_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
           python --version
-          python -m pip install '.[testing, doc]' \
+          python -m pip install ".[${FEW_EXTRAS}]" \
             --config-settings=cmake.define.FEW_WITH_GPU=OFF \
             --config-settings=cmake.define.FEW_LAPACKE_FETCH=OFF \
             --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
@@ -97,6 +105,7 @@ jobs:
         run: |
           coverage run --source=few -m unittest discover
       - name: Run doc tests
+        if: steps.disabling_doctests.outcome != 'success'
         run: |
           coverage run --source=few -m sphinx.cmd.build -M doctest docs/source docs/build
       - name: Show coverage results

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -81,24 +81,16 @@ jobs:
         if: matrix.os == 'macos-14' || matrix.os == 'macos-15'
         run: |
           echo "LAPACK_PKG_CONFIG_PATH=/opt/homebrew/opt/lapack/lib/pkgconfig" >> "$GITHUB_ENV"
-      - name: Enable doctest testing
-        run: |
-          echo "FEW_EXTRAS=testing,doc" >> "$GITHUB_ENV"
-      - name: Disable doctest testing
-        id: disabling_doctests
-        if: matrix.python-version != '3.9' &&  matrix.python-version != '3.12'
-        run: |
-          echo "FEW_EXTRAS=testing" >> "$GITHUB_ENV"
       - name: Install package
         run: |
           which python
           export PKG_CONFIG_PATH=${LAPACK_PKG_CONFIG_PATH}:${PKG_CONFIG_PATH}
           python --version
-          python -m pip install ".[${FEW_EXTRAS}]" \
+          python -m pip install multispline==0.8.2
+          python -m pip install ".[testing,doc]" \
             --config-settings=cmake.define.FEW_WITH_GPU=OFF \
             --config-settings=cmake.define.FEW_LAPACKE_FETCH=OFF \
-            --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG \
-            -vvv --config-settings=cmake.verbose=true --config-settings=logging.level=INFO
+            --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
       - name: Install coverage
         run: |
           python -m pip install coverage[toml]
@@ -106,7 +98,6 @@ jobs:
         run: |
           coverage run --source=few -m unittest discover
       - name: Run doc tests
-        if: steps.disabling_doctests.outcome != 'success'
         run: |
           coverage run --source=few -m sphinx.cmd.build -M doctest docs/source docs/build
       - name: Show coverage results


### PR DESCRIPTION
Small PR to prevent CI from using multispline 0.8.3 since the wheel `multispline-0.8.3-cp310-cp310-macosx_11_0_arm64.whl` is corrupted and makes some runners fail.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--127.org.readthedocs.build/en/127/

<!-- readthedocs-preview fastemriwaveforms end -->