### PR TITLE
Proposal: set documentation "collapse navigation" to False

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -149,7 +149,7 @@ html_theme_options = {
     "prev_next_buttons_location": "both",
     "style_nav_header_background": "coral",
     # Toc options
-    "collapse_navigation": True,
+    "collapse_navigation": False,
     "sticky_navigation": True,
     "navigation_depth": 4,
 }


### PR DESCRIPTION
This PR is just a proposal, feel free to discard it.

I personnally find RTD documentation easier to navigate when the option `collapse_navigation` is set to `False`.

See the documentation built for this PR to see the difference: now all menu items can be uncollapsed so we can see the subsections of each page without navigating to it.


<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--129.org.readthedocs.build/en/129/

<!-- readthedocs-preview fastemriwaveforms end -->