### PR TITLE
Replace zenodo DOI for v1.5.1 by version-independent DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -42,7 +42,7 @@ identifiers:
 repository-code: >-
   https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms
 url: 'https://bhptoolkit.org/FastEMRIWaveforms/html/index.html'
-repository: 'https://zenodo.org/records/8190418'
+repository: 'https://zenodo.org/records/3969004'
 repository-artifact: 'https://pypi.org/project/fastemriwaveforms/'
 abstract: >-
   This package contains the highly modular framework for

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # few: Fast EMRI Waveforms
 
-This package contains the highly modular framework for fast and accurate extreme mass ratio inspiral (EMRI) waveforms from [arxiv.org/2104.04582](https://arxiv.org/abs/2104.04582) and [arxiv.org/2008.06071](https://arxiv.org/abs/2008.06071). The waveforms in this package combine a variety of separately accessible modules to form EMRI waveforms on both CPUs and GPUs. Generally, the modules fall into four categories: trajectory, amplitudes, summation, and utilities. Please see the [documentation](https://bhptoolkit.org/FastEMRIWaveforms/) for further information on these modules. The code can be found on Github [here](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms). The data necessary for various modules in this package will automatically download the first time it is needed. If you would like to view the data, it can be found on [Zenodo](https://zenodo.org/record/3981654#.XzS_KRNKjlw). The current and all past code release zip files can also be found on Zenodo [here](https://zenodo.org/record/8190418). Please see the [citation](#citation) section below for information on citing FEW.
+This package contains the highly modular framework for fast and accurate extreme mass ratio inspiral (EMRI) waveforms from [arxiv.org/2104.04582](https://arxiv.org/abs/2104.04582) and [arxiv.org/2008.06071](https://arxiv.org/abs/2008.06071). The waveforms in this package combine a variety of separately accessible modules to form EMRI waveforms on both CPUs and GPUs. Generally, the modules fall into four categories: trajectory, amplitudes, summation, and utilities. Please see the [documentation](https://bhptoolkit.org/FastEMRIWaveforms/) for further information on these modules. The code can be found on Github [here](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms). The data necessary for various modules in this package will automatically download the first time it is needed. If you would like to view the data, it can be found on [Zenodo](https://zenodo.org/record/3981654#.XzS_KRNKjlw). The current and all past code release zip files can also be found on Zenodo [here](https://zenodo.org/record/3969004). Please see the [citation](#citation) section below for information on citing FEW.
 
 This package is a part of the [Black Hole Perturbation Toolkit](https://bhptoolkit.org/).
 
@@ -219,7 +219,7 @@ This project is licensed under the GNU License - see the [LICENSE](LICENSE) file
 
 ## Citation
 
-Please make sure to cite FEW papers and the FEW software on [Zenodo](https://zenodo.org/record/8190418). There are other papers that require citation based on the classes used. For most classes this applies to, you can find these by checking the `citation` attribute for that class. All references are detailed in the [CITATION.cff](CITATION.cff) file.
+Please make sure to cite FEW papers and the FEW software on [Zenodo](https://zenodo.org/record/3969004). There are other papers that require citation based on the classes used. For most classes this applies to, you can find these by checking the `citation` attribute for that class. All references are detailed in the [CITATION.cff](CITATION.cff) file.
 
 ## Acknowledgments
 

--- a/docs/source/dev/feat.md
+++ b/docs/source/dev/feat.md
@@ -76,7 +76,7 @@ $ few_citations few.amplitude.ampinterp2d.AmpInterp2D  # replace by your class m
   title      = "{FastEMRIWaveforms}",
   license    = "GPL-3.0",
   url        = "https://bhptoolkit.org/FastEMRIWaveforms/html/index.html",
-  repository = "https://zenodo.org/records/8190418",
+  repository = "https://zenodo.org/records/3969004",
   doi        = "10.5281/zenodo.3969004"
 }
 ```
@@ -92,7 +92,7 @@ You may also query the citations directly on an instance of your class:
   title      = "{FastEMRIWaveforms}",
   license    = "GPL-3.0",
   url        = "https://bhptoolkit.org/FastEMRIWaveforms/html/index.html",
-  repository = "https://zenodo.org/records/8190418",
+  repository = "https://zenodo.org/records/3969004",
   doi        = "10.5281/zenodo.3969004"
 }
 ```


### PR DESCRIPTION
Currently the documentation made use of the Zenodo DOI for version 1.5.1 specifically.
To make the documentation version independent, this PR replaces it with the project DOI.