### PR TITLE
Finalize project for PyPI release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,6 +73,7 @@ jobs:
           sed -i 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
       # Update project name
       - name: Add release suffix to project name
+        if: ${{ matrix.cuda_major }}
         run: |
           sed -i 's|" #@NAMESUFFIX@|-${{ matrix.release }}"|g' pyproject.toml
       # Add CuPy dependency
@@ -84,7 +85,7 @@ jobs:
       - name: Add core project dependency on plugin
         if: ${{ matrix.is_plugin }}
         run: |
-          sed -i 's|#@DEPS_FEWCORE@|"fastemriwaveforms-cpu==${{ github.ref_name }}"|g' pyproject.toml
+          sed -i 's|#@DEPS_FEWCORE@|"fastemriwaveforms==${{ github.ref_name }}"|g' pyproject.toml
       # Remove base sources from plugin wheels
       - name: Exclude core package from plugins
         if: ${{ matrix.is_plugin }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
           sed -i 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
       # Update project name
       - name: Add release suffix to project name
-        if: ${{ matrix.cuda_major }}
+        if: ${{ matrix.is_plugin }}
         run: |
           sed -i 's|" #@NAMESUFFIX@|-${{ matrix.release }}"|g' pyproject.toml
       # Add CuPy dependency

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To install the latest pre-compiled version of `fastemriwaveforms`, simply run:
 
 ```sh
 # For CPU-only version
-pip install fastemriwaveforms-cpu
+pip install fastemriwaveforms
 
 # For GPU-enabled versions with CUDA 11.Y.Z
 pip install fastemriwaveforms-cuda11x

--- a/README.md
+++ b/README.md
@@ -12,14 +12,17 @@ To install the latest pre-compiled version of `fastemriwaveforms`, simply run:
 
 ```sh
 # For CPU-only version
-pip install fastemriwaveforms
+pip install --pre fastemriwaveforms
 
 # For GPU-enabled versions with CUDA 11.Y.Z
-pip install fastemriwaveforms-cuda11x
+pip install --pre fastemriwaveforms-cuda11x
 
 # For GPU-enabled versions with CUDA 12.Y.Z
-pip install fastemriwaveforms-cuda12x
+pip install --pre fastemriwaveforms-cuda12x
 ```
+
+The `--pre-` flag means that you are installing a pre-release version of the project.
+This flag will not be necessary once version 2.0 is officially released.
 
 To know your CUDA version, run the tool `nvidia-smi` in a terminal a check the CUDA version reported in the table header:
 


### PR DESCRIPTION
this PR

- Changes the package name for PyPI release (`fastemriwaveforms` instead of the name used on testpypi `fastemriwaveforms-cpu`)
- Update the README accordingly
- For now, give install instructions using the `--pre` flag

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--136.org.readthedocs.build/en/136/

<!-- readthedocs-preview fastemriwaveforms end -->