### PR TITLE
Build wheels for more architectures

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,6 +124,7 @@ jobs:
         if: runner.os == 'macOS' && matrix.kind == 'core'
         uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_SKIP: pp*
           CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.reqpython }}
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
           CIBW_CONFIG_SETTINGS: cmake.define.FEW_LAPACKE_FETCH=ON cmake.define.FEW_WITH_GPU=OFF cmake.define.CMAKE_Fortran_COMPILER=${{ steps.setup-fortran.outputs.fc }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,146 +2,196 @@ name: Publish tagued version to TestPyPI
 on:
   push:
     tags:
-      - 'v*.*.*'
       - 'v*.*.**'
-      - 'v*.*.*-rc*'
-      - 'v*.*.*-rc**'
 permissions:
   contents: read
 jobs:
-  build_wheels:
-    name: Build manylinux wheels for FEW
-    runs-on: "ubuntu-latest"
-    container: ${{ matrix.image }}
-    defaults:
-      run:
-        shell: bash
+  cibw_build:
+    name: few-${{ matrix.release }} on ${{ matrix.os }}-${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    environment: pypiconf
     strategy:
       fail-fast: false
       matrix:
-        release: [cpu, cuda11x, cuda12x]
-        arch: [x86_64]
-        image: [quay.io/pypa/manylinux_2_28_x86_64]
-        manylinux_plat: [manylinux_2_27_x86_64]
         include:
           - release: cpu
-            opt_with_gpu: OFF
-            is_plugin: false
+            os: ubuntu-latest
+            arch: x86_64
+            kind: core
+            reqpython: '>=3.9'
           - release: cuda11x
+            os: ubuntu-latest
+            arch: x86_64
+            kind: cuda_plugin
             cuda_major: 11
             cuda_minor: 8
-            nvcc_ccbin_ver: 11
-            opt_with_gpu: ONLY
-            is_plugin: true
+            reqpython: '>=3.9'
           - release: cuda12x
+            os: ubuntu-latest
+            arch: x86_64
+            kind: cuda_plugin
             cuda_major: 12
-            cuda_minor: 6
-            nvcc_ccbin_ver: 11
-            opt_with_gpu: ONLY
-            is_plugin: true
+            cuda_minor: 4
+            reqpython: '>=3.9'
+          - release: cpu
+            os: ubuntu-24.04-arm
+            arch: aarch64
+            kind: core
+            reqpython: '>=3.10'
+          # - release: cuda11x
+          #   os: ubuntu-latest
+          #   arch: aarch64
+          #   target: manylinux
+          #   kind: cuda_plugin
+          #   cuda_major: 11
+          #   cuda_minor: 8
+          # - release: cuda12x
+          #   os: ubuntu-latest
+          #   arch: aarch64
+          #   target: manylinux
+          #   kind: cuda_plugin
+          #   cuda_major: 12
+          #   cuda_minor: 6
+          - release: cpu
+            os: macos-13
+            kind: core
+            reqpython: '>=3.9'
+            arch: x86_64
+            macos_ver: 13.0
+          - release: cpu
+            os: macos-14
+            kind: core
+            reqpython: '>=3.9'
+            arch: arm64
+            macos_ver: 14.0
     steps:
-      # Checkout sources
+      # =========================
+      # = I - Retrieve sources  =
+      # =========================
       - uses: actions/checkout@v4
-      - name: Prepare environment file
-        run: |
-          touch .compiler.env
-      # Install CUDA Toolkit
-      - name: Install CUDA Toolkit
-        if: ${{ matrix.cuda_major }}
-        run: |
-          dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
-          dnf -y install cuda-compiler-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }}.${{ matrix.arch }} \
-                   cuda-libraries-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }} \
-                   cuda-libraries-devel-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }}
-          echo 'export PATH=/usr/local/cuda/bin:${PATH}' >> .compiler.env
-          echo 'export LD_LIBRARY_PATH=/usr/local/cuda/lib64:${LD_LIBRARY_PATH}' >> .compiler.env
-          echo 'export CUDA_HOME=/usr/local/cuda' >> .compiler.env
-          echo 'export CUDA_ROOT=/usr/local/cuda' >> .compiler.env
-          echo 'export CUDA_PATH=/usr/local/cuda' >> .compiler.env
-          echo 'export CUDADIR=/usr/local/cuda' >> .compiler.env
-          cat .compiler.env
-      - name: Install GCC Toolset
-        if: ${{ matrix.nvcc_ccbin_ver }}
-        run: |
-          dnf install -y gcc-toolset-${{ matrix.nvcc_ccbin_ver }}
-          echo 'source /opt/rh/gcc-toolset-${{ matrix.nvcc_ccbin_ver }}/enable' >> .compiler.env
-          cat .compiler.env
-      # Update project name
+      # ========================
+      # = II - Update sources  =
+      # ========================
       - name: Update version scheme
         run: |
-          sed -i 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
-          sed -i 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
-      # Update project name
+          sed -i'' -e 's|version_scheme = "no-guess-dev"|version_scheme = "only-version"|g' pyproject.toml
+          sed -i'' -e 's|local_scheme = "node-and-date"|local_scheme = "no-local-version"|g' pyproject.toml
+          sed -i'' -e 's|#@FALLBACK_VERSION@|fallback_version = "${{ github.ref_name }}"|g' pyproject.toml
       - name: Add release suffix to project name
-        if: ${{ matrix.is_plugin }}
+        if: matrix.kind != 'core'
         run: |
-          sed -i 's|" #@NAMESUFFIX@|-${{ matrix.release }}"|g' pyproject.toml
+          sed -i'' -e 's|" #@NAMESUFFIX@|-${{ matrix.release }}"|g' pyproject.toml
+      - name: Add release suffix to core package for TestPyPI
+        if: matrix.kind == 'core' && vars.TWINE_REPOSITORY == 'testpypi'
+        run: |
+          sed -i'' -e 's|" #@NAMESUFFIX@|-${{ matrix.release }}"|g' pyproject.toml
       # Add CuPy dependency
       - name: Add Cupy dependency
-        if: ${{ matrix.cuda_major }}
+        if: matrix.kind == 'cuda_plugin'
         run: |
-          sed -i 's|#@DEPS_CUPYCUDA@|"cupy-${{ matrix.release }}"|g' pyproject.toml
+          sed -i'' -e 's|#@DEPS_CUPYCUDA@|"cupy-cuda${{ matrix.cuda_major }}x"|g' pyproject.toml
       # Add Core project dependency
       - name: Add core project dependency on plugin
-        if: ${{ matrix.is_plugin }}
+        if: matrix.kind != 'core' && vars.TWINE_REPOSITORY == 'testpypi'
         run: |
-          sed -i 's|#@DEPS_FEWCORE@|"fastemriwaveforms==${{ github.ref_name }}"|g' pyproject.toml
+          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms-cpu==${{ github.ref_name }}"|g' pyproject.toml
+      - name: Add core project dependency on plugin
+        if: matrix.kind != 'core' && vars.TWINE_REPOSITORY != 'testpypi'
+        run: |
+          sed -i'' -e 's|#@DEPS_FEWCORE@|"fastemriwaveforms==${{ github.ref_name }}"|g' pyproject.toml
       # Remove base sources from plugin wheels
       - name: Exclude core package from plugins
-        if: ${{ matrix.is_plugin }}
+        if: matrix.kind != 'core'
         run: |
-          sed -i '/@SKIP_PLUGIN@/d' pyproject.toml
-      - name: Compile LAPACK
-        if: ${{ matrix.opt_with_gpu != 'ONLY' }}
-        run: |
-          source .compiler.env
-
-          git clone https://github.com/Reference-LAPACK/lapack
-          git -C lapack reset --hard 6ec7f2bc4ecf4c4a93496aa2fa519575bc0e39ca  # version 3.12.1
-          cmake -B lapack/build -S lapack -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DLAPACKE=ON -DCMAKE_INSTALL_PREFIX=/opt/lapack
-          cmake --build lapack/build -- -j
-          cmake --install lapack/build
-          rm -Rf lapack
-          echo 'export PKG_CONFIG_PATH=/opt/lapack/lib64/pkgconfig/:${PKG_CONFIG_PATH}' >> .compiler.env
-      # Build wheels
-      - name: Build wheels
-        run: |
-          source .compiler.env
-
-          for PYVER in cp39-cp39 cp310-cp310 cp311-cp311 cp312-cp312 cp313-cp313; do
-             "/opt/python/${PYVER}/bin/pip" wheel ./ \
-                --no-deps -w ./dist \
-                --config-settings=cmake.define.FEW_LAPACKE_FETCH=OFF \
-                --config-settings=cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG \
-                --config-settings=cmake.define.FEW_LAPACKE_LIBS="PkgConfig::LAPACKE;PkgConfig::LAPACK;gfortran" \
-                --config-settings=cmake.define.FEW_WITH_GPU=${{ matrix.opt_with_gpu }} &
-          done;
-          wait
-      - name: Repair wheels (GPU)
-        if: ${{ matrix.cuda_major }}
-        run: |
-          for whl in ./dist/*.whl; do
-            auditwheel repair "${whl}" -w /wheelhouse/ \
-              --plat ${{ matrix.manylinux_plat }} \
-              --exclude "libcudart.so.${{ matrix.cuda_major }}" \
-              --exclude "libcusparse.so.${{ matrix.cuda_major }}" \
-              --exclude "libcublas.so.${{ matrix.cuda_major }}" \
-              --exclude "libnvJitLink.so.${{ matrix.cuda_major }}" \
-              --exclude "libcublasLt.so.${{ matrix.cuda_major }}"
-          done
-      - name: Repair wheels (CPU)
-        if: ${{ ! matrix.cuda_major }}
-        run: |
-          for whl in ./dist/*.whl; do
-            auditwheel repair "${whl}" -w /wheelhouse/ \
-              --plat ${{ matrix.manylinux_plat }}
-          done
-      - name: Upload wheels as artifacts
-        uses: actions/upload-artifact@v4
+          sed -i'' -e '/@SKIP_PLUGIN@/d' pyproject.toml
+      # ===================================
+      # = III. Prepare build environment  =
+      # ===================================
+      - name: Set up QEMU
+        if: matrix.os == 'ubuntu-latest' && matrix.arch != 'x86_64'
+        uses: docker/setup-qemu-action@v3
         with:
-          name: release-wheels-${{ matrix.release }}
-          path: /wheelhouse/*.whl
-          retention-days: 2
+          platforms: all
+      # =====================
+      # = IV. Build wheels  =
+      # =====================
+      - uses: fortran-lang/setup-fortran@v1
+        id: setup-fortran
+        with:
+          compiler: gcc
+          version: 14
+      - name: Build core wheels (macOS)
+        if: runner.os == 'macOS' && matrix.kind == 'core'
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.reqpython }}
+          CIBW_ARCHS_MACOS: ${{ matrix.arch }}
+          CIBW_CONFIG_SETTINGS: cmake.define.FEW_LAPACKE_FETCH=ON cmake.define.FEW_WITH_GPU=OFF cmake.define.CMAKE_Fortran_COMPILER=${{ steps.setup-fortran.outputs.fc }}
+          CIBW_TEST_COMMAND: python -c "import few; assert few.has_backend('cpu')"
+          MACOSX_DEPLOYMENT_TARGET: ${{ matrix.macos_ver }}
+
+      - name: Build core wheels (Linux)
+        if: runner.os == 'Linux' && matrix.kind == 'core'
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.reqpython }}
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_SKIP: pp* *musllinux*
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux_2_28
+          CIBW_CONFIG_SETTINGS: >
+            cmake.define.FEW_LAPACKE_FETCH=OFF
+            cmake.define.FEW_LAPACKE_DETECT_WITH=PKGCONFIG
+            cmake.define.FEW_LAPACKE_LIBS="PkgConfig::LAPACKE;PkgConfig::LAPACK;gfortran"
+            cmake.define.FEW_WITH_GPU=OFF
+
+          CIBW_BEFORE_ALL: >
+            git clone https://github.com/Reference-LAPACK/lapack &&
+            git -C lapack reset --hard 6ec7f2bc4ecf4c4a93496aa2fa519575bc0e39ca &&
+            cmake -B lapack/build -S lapack -DCMAKE_POSITION_INDEPENDENT_CODE=ON -DLAPACKE=ON -DCMAKE_INSTALL_PREFIX=/opt/lapack &&
+            cmake --build lapack/build -- -j &&
+            cmake --install lapack/build &&
+            rm -Rf lapack
+
+          CIBW_ENVIRONMENT: >
+            PKG_CONFIG_PATH="/opt/lapack/lib64/pkgconfig/:${PKG_CONFIG_PATH}"
+
+          CIBW_TEST_COMMAND: python -c "import few; assert few.has_backend('cpu')"
+
+      - name: Build cuda plugin wheels (Linux)
+        if: runner.os == 'Linux' && matrix.kind == 'cuda_plugin' && matrix.arch == 'x86_64'
+        uses: pypa/cibuildwheel@v2.22.0
+        env:
+          CIBW_PROJECT_REQUIRES_PYTHON: ${{ matrix.reqpython }}
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_SKIP: pp* *musllinux*
+          CIBW_CONFIG_SETTINGS: >
+            cmake.define.FEW_LAPACKE_FETCH=OFF
+            cmake.define.FEW_WITH_GPU=ONLY
+
+          CIBW_BEFORE_ALL: >
+            yum install -y devtoolset-11-gcc-c++ &&
+            yum-config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo &&
+            yum install -y cuda-compiler-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }}.${{ matrix.arch }} cuda-libraries-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }} cuda-libraries-devel-${{ matrix.cuda_major }}-${{ matrix.cuda_minor }}
+          CIBW_BEFORE_BUILD: source /opt/rh/devtoolset-11/enable
+
+          CIBW_ENVIRONMENT: >
+            PATH="/usr/local/cuda/bin:${PATH}"
+            LD_LIBRARY_PATH="/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+            CUDA_HOME=/usr/local/cuda
+            CUDA_ROOT=/usr/local/cuda
+            CUDA_PATH=/usr/local/cuda
+            CUDADIR=/usr/local/cuda
+            CC=gcc
+            CXX=g++
+
+          CIBW_REPAIR_WHEEL_COMMAND: auditwheel repair -w {dest_dir} {wheel} --exclude "libcudart.so.${{ matrix.cuda_major }}" --exclude "libcusparse.so.${{ matrix.cuda_major }}" --exclude "libcublas.so.${{ matrix.cuda_major }}" --exclude "libnvJitLink.so.${{ matrix.cuda_major }}" --exclude "libcublasLt.so.${{ matrix.cuda_major }}"
+      # =====================
+      # = V. Upload wheels  =
+      # =====================
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cibw-wheels-${{ strategy.job-index }}
+          path: ./wheelhouse/*.whl
   publish:
     runs-on: ubuntu-latest
     environment: pypiconf
@@ -149,7 +199,7 @@ jobs:
       run:
         shell: bash
     needs:
-      - build_wheels
+      - cibw_build
     permissions:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,8 +13,6 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
         args: ['--fix=auto']
-      - id: name-tests-test
-        args: ["--pytest-test-first"]
       - id: pretty-format-json
         args: [--autofix, --indent, "4"]
       - id: requirements-txt-fixer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ authors = [
   { name = "Niels Warburton", email = "nielsw@gmail.com" },
   { name = "Scott Hughes" },
 ]
+requires-python = ">=3.9"
+
 classifiers = [
   "Environment :: GPU :: NVIDIA CUDA",
   "License :: OSI Approved :: MIT License",
@@ -35,7 +37,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
 ]
-
 # version is deduced from the lattest git tag
 # description is the docstring at the top of src/few/__init__.py
 dynamic = [ "version" ]
@@ -96,6 +97,7 @@ scripts.few_files = "few.cmd.files:main"
 version_scheme = "no-guess-dev"
 local_scheme = "node-and-date"
 version_file = "src/few/_version.py"
+#@FALLBACK_VERSION@
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,4 +200,5 @@ paths.source = [
 
 report.omit = [
   "*/few/_version.py",
+  "*/few/tests/*.py",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ version_file = "src/few/_version.py"
 
 [tool.scikit-build]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-sdist.include = [ "src/few/_version.py" ]
+sdist.include = [ "src/few/_version.py", "tests/" ]
 sdist.exclude = [
   ".devcontainer/",
   ".github/",
@@ -108,7 +108,6 @@ sdist.exclude = [
   "EllipticIntegrals/",
   "examples/",
   "KerrEquatorialCodes/",
-  "tests/",
   ".cmake-format.yaml",
   ".gitignore",
   ".pre-commit-config.yaml",
@@ -122,9 +121,7 @@ sdist.exclude = [
   "TODO.txt",
   "Tutorial_interpolation.ipynb",
 ]
-wheel.packages = [
-  "src/few", #@SKIP_PLUGIN@
-]
+
 wheel.exclude = [
   "**.pyx",
   "**.cu",
@@ -138,6 +135,10 @@ wheel.exclude = [
   "lib/*.so",
   "lib/*.a",
 ]
+
+[tool.scikit-build.wheel.packages]
+few = "src/few"       #@SKIP_PLUGIN@
+"few/tests" = "tests" #@SKIP_PLUGIN@
 
 [tool.scikit-build.cmake.define]
 # Default values for CMake options used when building FEW.

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,0 +1,8 @@
+if __name__ == "__main__":
+    import unittest
+    import pathlib
+
+    current_directory = pathlib.Path(__file__).parent
+    suite = unittest.TestLoader().discover(start_dir=current_directory)
+    runner = unittest.TextTestRunner()
+    runner.run(suite)


### PR DESCRIPTION
This PR adds target architectures when building wheels for the core package `fastemriwaveforms`, it now build wheels for:

- manylinux aarch64
- macos on x86_64 platforms
- macos on arm64 platforms

In upcoming days/weeks I'd like to also build the manylinux aarch64 wheels for the cuda plugins, and ideally to build universal2 wheels for macos. But this will be done in a future PR.

I also made the following modifications:

- [x] Now the content of `tests/` is installed as a subpackage `few.tests` that we can run by executing `python -m few.tests` instead of `python -m unittest discover`: we don't need a copy of FEW sources anymore to check that an installation from package is working
- [x] When wheels are built, they are locally installed during the process to check they work correctly. For the core package, we check that `import few` works. For plugin installs, we only check that the install works
- [x] The workflow has been entirely rewritten, it should be easy to add more wheel target platforms in the future

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--138.org.readthedocs.build/en/138/

<!-- readthedocs-preview fastemriwaveforms end -->