### PR TITLE
fix: remove authors emails to fix display on pypi

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ maintainers = [
 ]
 
 authors = [
-  { name = "Michael Katz", email = "mikekatz04@gmail.com" },
-  { name = "Lorenzo Speri", email = "lorenzo.speri@gmail.com" },
-  { name = "Christian Chapman-Bird", email = "c.chapmanbird@gmail.com" },
+  { name = "Michael Katz" },
+  { name = "Lorenzo Speri" },
+  { name = "Christian Chapman-Bird" },
   { name = "Alvin J. K. Chua" },
-  { name = "Niels Warburton", email = "nielsw@gmail.com" },
+  { name = "Niels Warburton" },
   { name = "Scott Hughes" },
 ]
 requires-python = ">=3.9"


### PR DESCRIPTION
The current `v2.0rc0` release on PyPI has incorrect metadata displayed for authors:
![image](https://github.com/user-attachments/assets/c65018fc-e7da-4e6e-b1bf-596c9d85dbee)

Despite the metadata in the wheels being supposedly correct:

```
Author: Alvin J. K. Chua, Scott Hughes
Author-Email: Michael Katz <mikekatz04@gmail.com>, Lorenzo Speri <lorenzo.speri@gmail.com>, Christian Chapman-Bird <c.chapmanbird@gmail.com>, Niels Warburton <nielsw@gmail.com>
Maintainer-Email: Michael Katz <mikekatz04@gmail.com>, Christian Chapman-Bird <c.chapmanbird@gmail.com>
```

This is a [known issue](https://github.com/pypi/warehouse/issues/9400) with [ongoing discussions](https://discuss.python.org/t/combining-author-maintainer-names-emails-in-core-metadata/81011/6) but for now, I simply remove email adresses so that all authors appear in the metadata `Author` section instead of the `Author-Email` which will make all authors visible in PyPI.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--140.org.readthedocs.build/en/140/

<!-- readthedocs-preview fastemriwaveforms end -->