### PR TITLE
Add official support for Python 3.13 and test Linux arm64 platforms

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-24.04", "ubuntu-22.04", "macos-13", "macos-14", "macos-15"] #, "windows-latest"]
+        os: ["ubuntu-24.04", "ubuntu-22.04", "macos-13", "macos-14", "macos-15", "ubuntu-24.04-arm"] #, "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # cuda-version: ["12.4.0"]
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-24.04", "ubuntu-22.04", "macos-13", "macos-14", "macos-15"] #, "windows-latest"]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # cuda-version: ["12.4.0"]
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 # version is deduced from the lattest git tag
 # description is the docstring at the top of src/few/__init__.py
@@ -190,7 +191,7 @@ lint.ignore = [ "E741" ]
 lint.extend-per-file-ignores."*.ipynb" = [ "T201" ] # Allow "print" statements in notebooks
 
 [tool.pyproject-fmt]
-max_supported_python = "3.12"
+max_supported_python = "3.13"
 
 [tool.coverage]
 paths.source = [


### PR DESCRIPTION
The new wheel build process (#138 ) automatically built wheels for Python 3.13 (which used not to work when #111 was implemented).

therefore, this PR adds tests for this new Python version. It also makes use of recently deployed `ubuntu-24.04-arm` github-actions runners to tests FEW on that architecture.

Waiting for tests to be executed before marking that PR as ready to be merged.