### PR TITLE
Fix generation of GitHub Pages

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -18,6 +18,11 @@ jobs:
         if: contains(github.event.head_commit.message, '[ci:build-pages]')
         run: |
           echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
+      - name: build on commit message
+        if: contains(github.event.head_commit.message, '[ci:publish-pages]')
+        run: |
+          echo "FEWPAGE_BUILD=true" >> "$GITHUB_ENV"
+          echo "FEWPAGE_PUBLISH=true" >> "$GITHUB_ENV"
       - name: execute notebooks on request
         if: contains(github.event.head_commit.message, '[doc:run-notebooks]')
         run: |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This package contains a highly modular framework for the rapid generation of acc
 
 * Generally, the modules fall into four categories: trajectory, amplitudes, summation, and utilities. Please see the [documentation](https://fastemriwaveforms.readthedocs.io/en/latest) for further information on these modules.
 * The code can be found on Github [here](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms).
-* The data necessary for various modules in this package will automatically download the first time it is needed. If you would like to view the data, it can be found on [Zenodo](https://zenodo.org/record/3981654).
-* The current and all past code release zip files can also be found on Zenodo [here](https://zenodo.org/record/3969004).
+* The data necessary for various modules in this package will automatically download the first time it is needed. If you would like to view the data, it can be found on [Zenodo](https://zenodo.org/records/3981654).
+* The current and all past code release zip files can also be found on Zenodo [here](https://zenodo.org/records/3969004).
 
 **Please see the [citation](#citation) section below for information on citing FEW.** This package is part of the [Black Hole Perturbation Toolkit](https://bhptoolkit.org/).
 
@@ -312,7 +312,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Citation
 
-Please make sure to cite FEW papers and the FEW software on [Zenodo](https://zenodo.org/record/3969004).
+Please make sure to cite FEW papers and the FEW software on [Zenodo](https://zenodo.org/records/3969004).
 We provide a set of prepared references in [PAPERS.bib](PAPERS.bib). There are other papers that require citation based on the classes used. For most classes this applies to, you can find these by checking the `citation` attribute for that class.  All references are detailed in the [CITATION.cff](CITATION.cff) file.
 
 ## Acknowledgments

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ The above exception was the direct cause of the following exception:
 few.cutils.BackendAccessException: Backend 'cuda12x' is unavailable. See previous error messages.
 ```
 
-Once FEW is working and the expected backends are selected, check out the [examples notebooks](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/blob/master/examples/)
+Once FEW is working and the expected backends are selected, check out the [examples notebooks](https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/examples/)
 on how to start with this software.
 
 ## Installing from sources

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -93,7 +93,12 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3.11", None),
 }
 
-linkcheck_ignore = [r"https://dx.doi.org/", r"https://hpc.pages.cnes.fr/.*"]
+linkcheck_ignore = [
+    r"https://dx.doi.org/",
+    r"https://hpc.pages.cnes.fr/.*",
+    r"https://jupyterhub.cnes.fr/.*",
+    r"https://bhptoolkit.org/FastEMRIWaveforms/.*",
+]
 
 myst_heading_anchors = 2
 myst_url_schemes = {

--- a/src/few/cutils/wrappers.py
+++ b/src/few/cutils/wrappers.py
@@ -64,7 +64,7 @@ def pointer_adjust(func):
     If you use this decorator, you must convert input arrays to size_t data type in Cython and
     then properly cast the pointer as it enters the c++ function. See the
     Cython codes
-    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/few/cutils/src>`_
+    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/src/few/cutils>`_
     for examples.
 
     """

--- a/src/few/files/registry.yml
+++ b/src/few/files/registry.yml
@@ -4,7 +4,7 @@ repositories:
   - name: bhptk_kerreq
     url_pattern: "https://download.bhptoolkit.org/few/data/KerrEq/%(filename)s"
   - name: zenodo
-    url_pattern: "https://zenodo.org/record/15624459/files/%(filename)s"
+    url_pattern: "https://zenodo.org/records/15624459/files/%(filename)s"
 files:
   - name: AmplitudeVectorNorm.dat
     repositories:

--- a/src/few/summation/interpolatedmodesum.py
+++ b/src/few/summation/interpolatedmodesum.py
@@ -20,7 +20,7 @@ class CubicSplineInterpolant(ParallelModuleBase):
     `scipy.interpolate.CubicSpline <https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.CubicSpline.html#cubicspline>`_.
     However, the most efficient way to use this method is in a customized
     cuda kernel. See the
-    `source code for the interpolated summation <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/blob/master/few/cutils/src/interpolate.cu>`_
+    `source code for the interpolated summation <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/blob/master/src/few/cutils/interpolate.cu>`_
     in cuda for an example of this.
 
     This class can be run on GPUs and CPUs.

--- a/src/few/utils/utility.py
+++ b/src/few/utils/utility.py
@@ -549,7 +549,7 @@ def wrapper(*args, **kwargs):
     If you use this function, you must convert input arrays to size_t data type in Cython and
     then properly cast the pointer as it enters the c++ function. See the
     Cython codes
-    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/few/cutils/src>`_
+    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/src/few/cutils>`_
     for examples.
 
     args:
@@ -621,7 +621,7 @@ def pointer_adjust(func):
     If you use this decorator, you must convert input arrays to size_t data type in Cython and
     then properly cast the pointer as it enters the c++ function. See the
     Cython codes
-    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/few/cutils/src>`_
+    `here <https://github.com/BlackHolePerturbationToolkit/FastEMRIWaveforms/tree/master/src/few/cutils>`_
     for examples.
 
     """


### PR DESCRIPTION
This PR fixes the publication of github pages (multiple links were broken when the master branch was overridden).

If the [workflow associated with this PR](https://github.com/mpigou/FastEMRIWaveforms/actions/runs/15579289523/job/43870534361) succeeds, the branch should be merged **with a custom commit message containing [ci:publish-pages]** to retrigger the build and publish steps of the github pages workflow.

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview fastemriwaveforms end -->