### PR TITLE
feat: add support for `-march=...` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,9 @@ set(FEW_CUDA_ARCH "native"
     CACHE STRING "CUDA Architecture targetted for FEW compilation (see doc of \
           CMAKE_CUDA_ARCHITECTURES).")
 
+set(FEW_MARCH "native"
+    CACHE STRING "Value of the -march compiler option if supported by compiler")
+
 # FEW_LAPACKE_DETECT_WITH sets the tool used to try to detect LAPACKE locally.
 # Possible values are:
 #
@@ -87,6 +90,20 @@ add_library(fastemriwaveforms INTERFACE)
 
 # ---- Enable building the CPU version of backends by default ----
 set_target_properties(fastemriwaveforms PROPERTIES WITH_CPU ON)
+
+# ---- Test whether the FEW_MARCH option is supported by CXX compiler ----
+include(CheckCXXCompilerFlag)
+set(FEW_MARCH_CXX_OPT "-march=${FEW_MARCH}")
+check_cxx_compiler_flag("${FEW_MARCH_CXX_OPT}" CXX_COMPILER_SUPPORTS_FEW_MARCH)
+if(CXX_COMPILER_SUPPORTS_FEW_MARCH)
+  set_property(TARGET fastemriwaveforms PROPERTY CXX_MARCH
+                                                 "${FEW_MARCH_CXX_OPT}")
+  message(STATUS "The CXX compiler supports option '${FEW_MARCH_CXX_OPT}'.")
+else()
+  message(
+    WARNING "The CXX compiler does not support option '${FEW_MARCH_CXX_OPT}'. \
+      It will be ignored.")
+endif()
 
 # ---- Optionnally check if GPU is supported ----
 if(FEW_WITH_GPU STREQUAL "AUTO")

--- a/src/few/cutils/CMakeLists.txt
+++ b/src/few/cutils/CMakeLists.txt
@@ -317,6 +317,11 @@ function(apply_cpu_backend_common_options libname)
 
   install(TARGETS ${target_name} DESTINATION few_backend_cpu)
 
+  get_target_property(FEW_CXX_MARCH_OPT fastemriwaveforms CXX_MARCH)
+  if(FEW_CXX_MARCH_OPT)
+    target_compile_options(${target_name} PRIVATE "${FEW_CXX_MARCH_OPT}")
+  endif()
+
   target_include_directories(${target_name} PRIVATE ${Python_NumPy_INCLUDE_DIR})
   target_compile_definitions(${target_name}
                              PRIVATE NPY_NO_DEPRECATED_API=NPY_1_9_API_VERSION)


### PR DESCRIPTION
This PR adds the possibility to build FEW with a command like:

```bash
pip install -e . -Ccmake.define.FEW_MARCH=x86-64-v3
```

which will apply the compile option `-march-x86-64-v3` for all C++ source files (only if the compiler supports this option, otherwise CMake raises a warning and the option is ignored).

By default, this option is set to `native` so that compilation is optimised for the CPU the package is built on.

I did this since, this morning, I noticed an issue with `multispline` where the conda package was built using `march=native` which caused the use of CPU instructions which are not universally available (and thus on CNES cluster I got a SIGILL exception).

By adding this option in FEW, I'll be able to compile multiple variants of the **conda package** for linux on x86_64 platforms for each level of common instructions set (`x86-64-v2` and `x86-64-v3`) and make sure one can only install a package which is supported by their current CPU.
I'll implement that only when the initial conda package is accepted on `conda-forge` and after we release the next version (2.0.1 or 2.1.0 I guess?).

(For the PyPI package, I will force the `x86-64-v2` instruction set since `pip` offers no method to differentiate the capabilities of the current CPU)

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--159.org.readthedocs.build/en/159/

<!-- readthedocs-preview fastemriwaveforms end -->