### PR TITLE
Correct minor typos in documentation

### DIFF
--- a/docs/source/dev/feat.md
+++ b/docs/source/dev/feat.md
@@ -199,7 +199,7 @@ The list of action to take to add a new configuration option is thus:
 The recommended way to print messages in FEW is to use the package [logger](logging.Logger).
 [pre-commit](./ide.md#pre-commit-apply-common-guidelines-to-your-code) will, by default, complain about the use of [`print`](print) statements which should be replaced by calls to the logger methods:
 
-- `few_logger.debug(message)`: should contain detailed information about the innerworking of a piece of code to guide a user or developper during debugging phases
+- `few_logger.debug(message)`: should contain detailed information about the inner working of a piece of code to guide a user or developer during debugging phases
 - `few_logger.info(message)`: should replace most print statements directed to the user
 - `few_logger.warning(message)`: should warn the user about unexpected states which are recoverable
 - `few_logger.error(message)`: should warn the user about unexpected state which are unrecoverable

--- a/docs/source/general/docs_main.rst
+++ b/docs/source/general/docs_main.rst
@@ -13,7 +13,7 @@ where :math:`h_+ + ih_x` is the two polarizations of the gravitational wave; :ma
 
 .. math:: A_{lmkn} = -2Z_{lmkn}(a, p, e, x_I)/\omega_{mkn}^2,
 
-where :math:`Z_{lmkn}(a, p, e, x_I)` is the teukolsky amplitudes associated with a geodesic with spin, :math:`a`; semilatus rectum, :math:`p`p; eccentricity, :math:`e`; and inclination, :math:`x_I`. :math:`\omega_{mkn}` is the summation of fundamental frequencies of the geodesic with integer weights equivalent to the mode indices. The angular function, :math:`V_{lmkn}` is given by,
+where :math:`Z_{lmkn}(a, p, e, x_I)` is the Teukolsky amplitudes associated with a geodesic with spin, :math:`a`; semilatus rectum, :math:`p`; eccentricity, :math:`e`; and inclination, :math:`x_I`. :math:`\omega_{mkn}` is the summation of fundamental frequencies of the geodesic with integer weights equivalent to the mode indices. The angular function, :math:`V_{lmkn}` is given by,
 
 .. math:: V_{lmkn}(\theta, \phi) = (s=-2)S_{lmkn}(\theta)e^{im\phi},
 

--- a/docs/source/user/cfg.md
+++ b/docs/source/user/cfg.md
@@ -42,7 +42,7 @@ The default log level is `logging.WARNING` but this can be modified through the 
 ### Backends management
 
 Backends are plugin-like entities which can be used to delegate heavy computations to specific hardware like GPUs.
-By default, FEW will try to use the best available backend for each class that the user instanciates. It is however
+By default, FEW will try to use the best available backend for each class that the user instantiates. It is however
 possible to enforce or prevent the use of specific backends through the `enabled_backends` options.
 
 The list of available backends is:
@@ -51,7 +51,7 @@ The list of available backends is:
 - `cuda11x`: Use a NVIDIA GPU with CUDA 11.x drivers
 - `cuda12x`: Use a NVIDIA GPU with CUDA 12.x drivers
 
-By default, all these backends can be used provided they are installed and have required sotware and hardware available.
+By default, all these backends can be used provided they are installed and have required software and hardware available.
 A class that supports only CPU will only attempt to use he `cpu` backend, whilst a class with hybrid GPU/CPU support will
 (usually) first attempt to use the `cuda12x` backend, in case of failure it will attempt using the `cuda11x` and finally
 fallback to the `cpu` one.
@@ -108,7 +108,7 @@ through the `file_registry_path` option.
 By default, the first time a file is requested to the `FileManager`, its integrity is checked and cached so that future request to that
 file are fast.
 
-This behaviour can be tuned to disable entirely integrity checks, or to perform these checks each and everytime a given file is requested.
+This behaviour can be tuned to disable entirely integrity checks, or to perform these checks each and every time a given file is requested.
 
 The `file_integrity_check` option can thus take on the following values:
 
@@ -131,7 +131,7 @@ General configuration options:
 |---|---|---|---|---|---|
 | `log_level` | `log-level` | `FEW_LOG_LEVEL` | `--log-level` | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |  |
 | `log_format` | `log-format` | `FEW_LOG_FORMAT` | `--log-format` | Any format string supported by [`logging.Formatter`](https://docs.python.org/3/library/logging.html#logging.Formatter) |  |
-| `enabled_backends` | `enbaled-backends` | `FEW_ENABLED_BACKENDS` | `--enable-backend` | `cpu`, `cuda11x`, `cuda12x` | ";"-separated list of values. The CLI parameter can be used multiple time for each enabled backend. |
+| `enabled_backends` | `enabled-backends` | `FEW_ENABLED_BACKENDS` | `--enable-backend` | `cpu`, `cuda11x`, `cuda12x` | ";"-separated list of values. The CLI parameter can be used multiple time for each enabled backend. |
 | `file_registry_path` | `file-registry` | `FEW_FILE_REGISTRY` | `--file-registry` | Path to a `registry.yml` file |  |
 | `file_storage_path` | `file-storage-dir` | `FEW_FILE_STORAGE_DIR` | `--storage-dir` | Absolute path, or relative to current working directory | Directory must already exist |
 | `file_download_path` | `file-download-dir` | `FEW_FILE_DOWNLOAD_DIR` | `--download-dir` | Absolute path, or relative to the storage directory |  |
@@ -202,7 +202,7 @@ immediately by calling the `finalize()` method like:
     few.get_config_setter().set_log_level("info").finalize()
 ```
 
-But if `finalize()` is not explicitely called, the options set will still be taken into account
+But if `finalize()` is not explicitly called, the options set will still be taken into account
 automatically at a latter stage:
 
 ```{eval-rst}

--- a/docs/source/user/install.md
+++ b/docs/source/user/install.md
@@ -44,7 +44,7 @@ To quickly find the right installation instructions for your needs, follow these
 |--------------------------|-----------------|--------|---------|--------------|------------------|
 | **Install via pip (user)**      | [Generic pip](#using-pip) | [Generic pip](#using-pip) | Not available | [Generic pip](#using-pip) | [CC-IN2P3 pip](#on-the-cc-in2p3-cluster-with-gpu-support) |
 | **Install via conda (user)**    | [Generic conda](#using-conda) | [Generic conda](#using-conda) | [Windows conda](#on-windows) | [Generic conda](#using-conda) | [CC-IN2P3 conda](#on-the-cc-in2p3-cluster-with-gpu-support) |
-| **From source (developper)**          | [Generic source](#from-source) | [Mac source](#on-mac-os-from-sources) | [Windows source](#on-windows) | [CNES source](#on-cnes-cluster-with-gpu-and-jupyter-hub-supports) | [CC-IN2P3 source](#on-the-cc-in2p3-cluster-with-gpu-support) |
+| **From source (developer)**          | [Generic source](#from-source) | [Mac source](#on-mac-os-from-sources) | [Windows source](#on-windows) | [CNES source](#on-cnes-cluster-with-gpu-and-jupyter-hub-supports) | [CC-IN2P3 source](#on-the-cc-in2p3-cluster-with-gpu-support) |
 | **GPU support**          | [See Generic](#generic-installation-instructions) | Not available | Not available | [CNES GPU](#on-cnes-cluster-with-gpu-and-jupyter-hub-supports) | [CC-IN2P3 GPU](#on-the-cc-in2p3-cluster-with-gpu-support) |
 | **Jupyter Hub**          | N/A | N/A | N/A | [CNES Jupyter](#make-the-conda-environment-available-as-a-jupyter-hub-kernel) | [CC-IN2P3 Jupyter](#enable-the-jupyter-hub-kernel) |
 
@@ -391,7 +391,7 @@ $ srun -p gpu_interactive -t 0-02:00 --mem 64G --gres=gpu:v100:1 --pty bash -i
 ```
 
 All installation methods described [above](#generic-installation-instructions)
-are available on the CC-IN2P3 cluster but need little adjustements.
+are available on the CC-IN2P3 cluster but need little adjustments.
 
 - For a **conda installation**, you can use the `anaconda` module available on the cluster.
   Load it and create a new environment named `few_env` with `fastemriwaveforms-cuda12x`:


### PR DESCRIPTION
This PR fixes some typos in the documentation.

As an aside, is there a convention on UK vs US spelling? I noticed a few examples, e.g. "behaviors" vs "behaviours".

<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--166.org.readthedocs.build/en/166/

<!-- readthedocs-preview fastemriwaveforms end -->