### PR TITLE
Fixing  xI_to_Y and Y_to_xI for retrograde orbits

### DIFF
--- a/src/few/utils/mappings/pn.py
+++ b/src/few/utils/mappings/pn.py
@@ -163,8 +163,9 @@ def _PN_E(q, p, e, Y):
     )
     rhs_numer = kappa * rho + 2.0 * epsilon * sigma
     rhs_denom = rho * rho + 4.0 * eta * sigma
-
-    E_square = (rhs_numer -np.sign(Y)* 2.0 * sqrt(rhs_sqrt)) / rhs_denom
+    # Determine if orbit is prograde (1) or retrograde (-1)
+    grade = - 1 if (Y < 0) ^ (q < 0)   else 1 # Retrograde if (Y<0) xor (q<0), else prograde
+    E_square = (rhs_numer -grade* 2.0 * sqrt(rhs_sqrt)) / rhs_denom
     return sqrt(E_square)
 
 

--- a/src/few/utils/mappings/pn.py
+++ b/src/few/utils/mappings/pn.py
@@ -164,7 +164,7 @@ def _PN_E(q, p, e, Y):
     rhs_numer = kappa * rho + 2.0 * epsilon * sigma
     rhs_denom = rho * rho + 4.0 * eta * sigma
 
-    E_square = (rhs_numer - 2.0 * sqrt(rhs_sqrt)) / rhs_denom
+    E_square = (rhs_numer -np.sign(Y)* 2.0 * sqrt(rhs_sqrt)) / rhs_denom
     return sqrt(E_square)
 
 


### PR DESCRIPTION
Fixes #161
All that was required was adding a sign change to the second term in the final expression in _PN_E for retrograde orbits.

Fix:

```python
def _PN_E(q, p, e, Y):

    # Rest of the function unchanged
    # Determine if orbit is prograde (1) or retrograde (-1)
    grade = - 1 if (Y < 0) ^ (q < 0)   else 1 # Retrograde if (Y<0) xor (q<0), else prograde
    E_square = (rhs_numer -grade* 2.0 * sqrt(rhs_sqrt)) / rhs_denom
    return sqrt(E_square)
```

Tests:
```python
a = 0.9
p = 10
e = 0.3
xI = -0.5

Y = xI_to_Y( a, p, e,xI)
xI_recovered = Y_to_xI( a, p, e,Y)

(xI,xI_recovered,xI-xI_recovered)
```
Output: 
``` python
(-0.5, -0.5000000000000002, 2.220446049250313e-16)
```

```python
a = 0.9
p = 10
e = 0.3
Y = -0.5

xI = Y_to_xI( a, p, e,Y)
Y_recovered = xI_to_Y( a, p, e,xI)

(Y,Y_recovered,Y-Y_recovered)
```
Output: 
```python
(-0.5, np.float64(-0.5000000000000001), np.float64(1.1102230246251565e-16))
```




<!-- readthedocs-preview fastemriwaveforms start -->
----
📚 Documentation preview 📚: https://fastemriwaveforms--169.org.readthedocs.build/en/169/

<!-- readthedocs-preview fastemriwaveforms end -->